### PR TITLE
add note about Pioneer DJM-850

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ spending some money.
 - ✓ [Native Instruments Audio 8 DJ](#native-instruments-audio-8-dj)
 - ✓ [Rane SL-1](#rane-sl-1)
 - ✖️ [Pioneer DJM-750MK2](#pioneer-djm-750mk2)
+- ✖️ [Pioneer DJM-850](#pioneer-djm-850)
 
 ## Allen & Heath XONE:K2
 
@@ -118,3 +119,14 @@ USB, 4 inputs, 4 outputs. Toggable phono preamps on all 4 inputs.
 USB, 10 inputs, 10 output (?). Toggleable phono preamps on 4 inputs.
 
 - https://www.pioneerdj.com/en-gb/product/mixer/djm-750mk2/black/overview/
+
+## Pioneer DJM-850
+
+- ✖️  Not working on GNU/Linux. Device can be listed with `lsusb`, MIDI may work
+but the built in audio soundcard doesn't work on GNU/Linux (propietary
+implementation (`Vendor Specific USB Class`), requires reverse engineering).
+
+- Vendor ID : `08e4`
+- Device ID : `0163`
+
+- https://www.pioneerdj.com/en/product/mixer/archive/djm-850/black/overview/

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ spending some money.
 - ✓ [Native Instruments Audio 4 DJ](#native-instruments-audio-4-dj)
 - ✓ [Native Instruments Audio 6](#native-instruments-audio-6)
 - ✓ [Native Instruments Audio 8 DJ](#native-instruments-audio-8-dj)
+- ✓ [Pioneer DJM-850](#pioneer-djm-850)
 - ✓ [Rane SL-1](#rane-sl-1)
 - ✖️ [Pioneer DJM-750MK2](#pioneer-djm-750mk2)
-- ✖️ [Pioneer DJM-850](#pioneer-djm-850)
 
 ## Allen & Heath XONE:K2
 
@@ -104,6 +104,14 @@ Set inputs to Phono: `$ amixer -c [cardnumber] cset numid=1 1`
 
 Set inputs to Line: `$ amixer -c [cardnumber] cset numid=1 0`
 
+## Pioneer DJM-850
+
+- ✓ Working since Linux 5.13
+
+USB, 8 inputs, 8 outputs. 24bits soundcard at 44.1kHz, 48kHz, 96kHz samplerate.
+
+Use the `alsamixer` command to choose the mixer's USB output options.
+
 ## Rane SL-1
 
 - ✓ Working on Fedora ~2011. Unable to turn on the phono preamps.
@@ -119,14 +127,3 @@ USB, 4 inputs, 4 outputs. Toggable phono preamps on all 4 inputs.
 USB, 10 inputs, 10 output (?). Toggleable phono preamps on 4 inputs.
 
 - https://www.pioneerdj.com/en-gb/product/mixer/djm-750mk2/black/overview/
-
-## Pioneer DJM-850
-
-- ✖️  Not working on GNU/Linux. Device can be listed with `lsusb`, MIDI may work
-but the built in audio soundcard doesn't work on GNU/Linux (propietary
-implementation (`Vendor Specific USB Class`), requires reverse engineering).
-
-- Vendor ID : `08e4`
-- Device ID : `0163`
-
-- https://www.pioneerdj.com/en/product/mixer/archive/djm-850/black/overview/


### PR DESCRIPTION
Sadly this device requires some [reverse engineering](https://kicherer.org/joomla/index.php/en/blog/38-reverse-engineering-a-usb-sound-card-with-midi-interface-for-linux).

There was recently a [patch added to ALSA](https://lore.kernel.org/alsa-devel/20200401095907.3387-1-konference@frantovo.cz/) for DJM-250 tho, maybe it can help a bit more to understand how's this one working.